### PR TITLE
fix typo (there was russian c, should be s)

### DIFF
--- a/res/values-sk/nitrogen_strings.xml
+++ b/res/values-sk/nitrogen_strings.xml
@@ -16,7 +16,7 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- Notification text containing download duration left and download speed -->
-    <string name="text_download_speed">%1$s, %2$s/с</string>
+    <string name="text_download_speed">%1$s, %2$s/s</string>
 
     <!-- Phrase describing a time duration using seconds [CHAR LIMIT=16] -->
     <string name="duration_seconds">%d s</string>


### PR DESCRIPTION
Fix typo - please merge. Thanks.